### PR TITLE
Remove duplicate variable definitions

### DIFF
--- a/docker/client/main.tf
+++ b/docker/client/main.tf
@@ -7,7 +7,6 @@ variable "deploy_ssh_hosts" {}
 variable "dns_names_list" { default = "*.*.cluster.internal,*.ec2.internal" }
 variable "docker_client_count" {}
 variable "private_key" {}
-variable "ca_cert_pem" {}
 variable "validity_period_hours" {}
 variable "early_renewal_hours" {}
 variable "user" {}

--- a/docker/daemon/main.tf
+++ b/docker/daemon/main.tf
@@ -7,7 +7,6 @@ variable "deploy_ssh_hosts" {}
 variable "dns_names_list" { default = "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local" }
 variable "docker_daemon_count" {}
 variable "private_key" {}
-variable "ca_cert_pem" {}
 variable "validity_period_hours" { default = 8760 }
 variable "early_renewal_hours" { default = 720 }
 variable "user" { default = "core" }


### PR DESCRIPTION
Duplicate definitions break `kubeform` Terraform 0.7.10 at least.