### PR TITLE
Updated to HCL syntax 0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+kubernetes/admin/admin-key.pem
+kubernetes/admin/admin.pem
+kubernetes/admin/ca.pem

--- a/ca/main.tf
+++ b/ca/main.tf
@@ -6,7 +6,7 @@ variable "is_ca_certificate" { default = true }
 variable "ca_count" {}
 # supports if you have a public/private ip and you want to set the private ip
 # for internal cert but use the public_ip to connect via ssh
-variable "deploy_ssh_hosts" {}
+variable "deploy_ssh_hosts" { default = [""] }
 variable "common_name" { default = "kube-ca" }
 variable "target_folder" { default = "/etc/kubernetes/ssl"}
 variable "user" { default = "core" }

--- a/docker/client/deploy.tf
+++ b/docker/client/deploy.tf
@@ -8,8 +8,8 @@ resource "null_resource" "configure-docker-client-certs" {
     docker_client_certs_pem   = "${element(tls_locally_signed_cert.docker_client.*.cert_pem, count.index)}"
     validity_period_hours     = "${var.validity_period_hours}"
     early_renewal_hours       = "${var.early_renewal_hours}"
-    ip_addresses_list         = "${var.ip_addresses_list}"
-    dns_names_list            = "${var.dns_names_list}"
+    ip_addresses_list         = "${join(",", var.ip_addresses_list)}"
+    dns_names_list            = "${join(",", var.dns_names_list)}"
   }
 
   connection {

--- a/docker/client/main.tf
+++ b/docker/client/main.tf
@@ -1,10 +1,10 @@
 variable "ca_cert_pem" {}
 variable "ca_private_key_pem" {}
-variable "ip_addresses_list" {}
+variable "ip_addresses_list" { default = [""] }
 # supports if you have a public/private ip and you want to set the private ip
 # for internal cert but use the public_ip to connect via ssh
-variable "deploy_ssh_hosts" {}
-variable "dns_names_list" { default = "*.*.cluster.internal,*.ec2.internal" }
+variable "deploy_ssh_hosts" { default = [""] }
+variable "dns_names_list" { default = ["*.*.cluster.internal", "*.ec2.internal"] }
 variable "docker_client_count" {}
 variable "private_key" {}
 variable "validity_period_hours" {}
@@ -25,7 +25,7 @@ resource "tls_cert_request" "docker_client" {
     common_name  = "docker_client_${count.index}"
   }
 
-  dns_names = ["${split(",", var.dns_names_list)}"]
+  dns_names = ["${var.dns_names_list}"]
   ip_addresses = ["${element(var.ip_addresses_list, count.index)}"]
 }
 

--- a/docker/daemon/deploy.tf
+++ b/docker/daemon/deploy.tf
@@ -8,8 +8,8 @@ resource "null_resource" "configure-docker-dameon-certs" {
     docker_daemon_certs_pem   = "${element(tls_locally_signed_cert.docker_daemon.*.cert_pem, count.index)}"
     validity_period_hours     = "${var.validity_period_hours}"
     early_renewal_hours       = "${var.early_renewal_hours}"
-    ip_addresses_list         = "${var.ip_addresses_list}"
-    dns_names_list            = "${var.dns_names_list}"
+    ip_addresses_list         = "${join(",", var.ip_addresses_list)}"
+    dns_names_list            = "${join(",", var.dns_names_list)}"
   }
 
   connection {

--- a/docker/daemon/main.tf
+++ b/docker/daemon/main.tf
@@ -1,10 +1,10 @@
 variable "ca_cert_pem" {}
 variable "ca_private_key_pem" {}
-variable "ip_addresses_list" {}
+variable "ip_addresses_list" { default = [""] }
 # supports if you have a public/private ip and you want to set the private ip
 # for internal cert but use the public_ip to connect via ssh
-variable "deploy_ssh_hosts" {}
-variable "dns_names_list" { default = "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local" }
+variable "deploy_ssh_hosts" { default = [""] }
+variable "dns_names_list" { default = ["kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc.cluster.local"] }
 variable "docker_daemon_count" {}
 variable "private_key" {}
 variable "validity_period_hours" { default = 8760 }
@@ -25,7 +25,7 @@ resource "tls_cert_request" "docker_daemon" {
     common_name = "docker_daemon"
   }
 
-  dns_names = ["${split(",", var.dns_names_list)}"]
+  dns_names = ["${var.dns_names_list}"]
   ip_addresses = [
     "127.0.0.1",
     "${element(var.ip_addresses_list, count.index)}"

--- a/kubernetes/kubelet/deploy.tf
+++ b/kubernetes/kubelet/deploy.tf
@@ -8,7 +8,7 @@ resource "null_resource" "configure-kubelet-certs" {
     kubelet_certs_pem      = "${element(tls_locally_signed_cert.kubelet.*.cert_pem, count.index)}"
     validity_period_hours  = "${var.validity_period_hours}"
     early_renewal_hours    = "${var.early_renewal_hours}"
-    ip_addresses           = "${var.ip_addresses}"
+    ip_addresses           = "${join(",", var.ip_addresses)}"
   }
 
   connection {

--- a/kubernetes/kubelet/main.tf
+++ b/kubernetes/kubelet/main.tf
@@ -1,9 +1,9 @@
 variable "ca_cert_pem" {}
 variable "ca_private_key_pem" {}
-variable "ip_addresses" {}
+variable "ip_addresses" { default = [""] }
 # supports if you have a public/private ip and you want to set the private ip
 # for internal cert but use the public_ip to connect via ssh
-variable "deploy_ssh_hosts" {}
+variable "deploy_ssh_hosts" { default = [""] }
 variable "kubelet_count" { default = "1" }
 variable "validity_period_hours" { default = "8760" }
 variable "early_renewal_hours" { default = "720" }

--- a/kubernetes/master/deploy.tf
+++ b/kubernetes/master/deploy.tf
@@ -7,8 +7,8 @@ resource "null_resource" "configure-master-certs" {
     master_certs_pem      = "${element(tls_locally_signed_cert.master.*.cert_pem, count.index)}"
     validity_period_hours = "${var.validity_period_hours}"
     early_renewal_hours   = "${var.early_renewal_hours}"
-    dns_names             = "${var.dns_names}"
-    ip_addresses          = "${var.ip_addresses}"
+    dns_names             = "${join(",", var.dns_names)}"
+    ip_addresses          = "${join(",", var.ip_addresses)}"
   }
 
   connection {

--- a/kubernetes/master/main.tf
+++ b/kubernetes/master/main.tf
@@ -1,10 +1,10 @@
 variable "ca_cert_pem" {}
 variable "ca_private_key_pem" {}
-variable "ip_addresses" {}
-variable "dns_names" { default = "" }
+variable "ip_addresses" { default = [""] }
+variable "dns_names" { default = [""] }
 # supports if you have a public/private ip and you want to set the private ip
 # for internal cert but use the public_ip to connect via ssh
-variable "deploy_ssh_hosts" {}
+variable "deploy_ssh_hosts" { default = [""] }
 variable "master_count" {}
 variable "kube_service_ip" { default = "10.3.0.1" }
 variable "validity_period_hours" { default = "8760" }
@@ -27,7 +27,7 @@ resource "tls_cert_request" "master" {
   }
 
   dns_names    = ["${compact(var.dns_names)}", "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc.cluster.local"]
-  ip_addresses = ["${concat(var.kube_service_ip, var.ip_addresses)}"]
+  ip_addresses = ["${concat(list(var.kube_service_ip), var.ip_addresses)}"]
 }
 
 resource "tls_locally_signed_cert" "master" {


### PR DESCRIPTION
I realised that I needed to update the Terraform syntax in order to work with Kubeform and Terraform client 0.7 so I'm sharing back what I did to get up and running.